### PR TITLE
Example of a Shopify plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,13 @@ cp -R grist-plugin-examples/examples/ ~/.grist/plugins
 |example-2-line-stats|`ParseFileAPI`, `SafePython`|
 |example-3-github|`ImportSourceAPI`, `SafeBrowser`|
 |example-4-ps-aux|`ImportSourceAPI`, `UnsafeNode`|
+|example-5-shopify|`ImportSourceAPI`, `UnsafeNode`, `SafeBrowser`|
 
 ### How to use
+
+Some examples may require an additional build step. Please consult each examples README.md for
+details. For example, Shopify (Example 5) requires an `npm install` step and a local configuration
+file with Shopify credentials.
 
 Examples with `ImportSourceAPI` can be used from the "Import" menu
 in the top right of Grist when editing a document.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cp -R grist-plugin-examples/examples/ ~/.grist/plugins
 
 ### How to use
 
-Some examples may require an additional build step. Please consult each examples README.md for
+Some examples may require an additional build step. Please consult each example's README.md for
 details. For example, Shopify (Example 5) requires an `npm install` step and a local configuration
 file with Shopify credentials.
 

--- a/examples/example-5-shopify/.gitignore
+++ b/examples/example-5-shopify/.gitignore
@@ -1,0 +1,1 @@
+**/node_modules/*

--- a/examples/example-5-shopify/README.md
+++ b/examples/example-5-shopify/README.md
@@ -1,0 +1,19 @@
+## Installation
+
+First, you'll need to install the required npm dependencies:
+
+1. Go to the `server` directory (e.g. `cd server`)
+2. Run `npm install`
+
+## Setup
+
+You'll need to add your Shopify store credentials to `.shopify` in your user's home director (e.g. `/Users/alice~/.shopify`).
+
+The following three parameters should be present in the file:
+
+```
+SHOPIFY_STORE_NAME="<your store name>"
+SHOPIFY_API_KEY="<your API key>"
+SHOPIFY_API_SECRET="<your API secret>"
+```
+

--- a/examples/example-5-shopify/index.html
+++ b/examples/example-5-shopify/index.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <script src="/grist-plugin-api.js"></script>
+    <script src="page.js"></script>
+  </head>
+  <body>
+    <form name='shopify'>
+      <fieldset>
+        <legend>Input source</legend>
+        <select id='category'>
+          <option value='product'>Products</option>
+          <option value='customer'>Customers</option>
+        </select>
+        <label for='category'>Category</label>
+      </fieldset>
+      <button type='submit'>Import</button>
+    </form>
+  </body>
+</html>

--- a/examples/example-5-shopify/main.js
+++ b/examples/example-5-shopify/main.js
@@ -1,0 +1,8 @@
+"use strict";
+
+/* global grist, self */
+
+self.importScripts('/grist-plugin-api.js');
+
+grist.addImporter('shopify', 'index.html', 'inline');
+grist.ready();

--- a/examples/example-5-shopify/manifest.yml
+++ b/examples/example-5-shopify/manifest.yml
@@ -1,0 +1,11 @@
+name: shopify
+version: 0.0.1
+components:
+  unsafeNode: server/index.js
+  safeBrowser: main.js
+contributions:
+  importSources:
+    - importSource:
+        component: safeBrowser
+        name: shopify
+      label: Import from Shopify

--- a/examples/example-5-shopify/page.js
+++ b/examples/example-5-shopify/page.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/* global grist, document, console */
+
+let resolve, reject;
+grist.rpc.registerImpl('shopify', {
+  getImportSource: () => new Promise((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  })
+});
+
+grist.ready();
+
+document.addEventListener('DOMContentLoaded', importShopify);
+
+function importShopify() {
+  document.forms.shopify.addEventListener('submit', ev => {
+    ev.preventDefault();
+    grist.rpc.callRemoteFunc('importShopify@server/index.js', {
+      category: document.forms.shopify.category.value
+    })
+    .then(resp => {
+      resolve(resp);
+    });
+  });
+}

--- a/examples/example-5-shopify/server/index.js
+++ b/examples/example-5-shopify/server/index.js
@@ -1,0 +1,26 @@
+const os = require('os');
+const path = require('path');
+require('dotenv').config({ path: path.resolve(os.homedir(), '.shopify') });
+const Shopify = require('shopify-api-node');
+
+const grist = require('grist-plugin-api');
+
+grist.rpc.registerFunc('importShopify', params => {
+  let shopify = new Shopify({
+    shopName: process.env.SHOPIFY_STORE_NAME,
+    apiKey: process.env.SHOPIFY_API_KEY,
+    password: process.env.SHOPIFY_API_SECRET
+  });
+
+  return shopify[params.category].list()
+    .then(data => {
+      return {
+        item: {
+          kind: 'fileList',
+          files: [{ content: JSON.stringify(data), name: 'shopify.json' }],
+        },
+        description: 'Import from Shopify'
+      };
+    });
+});
+grist.ready();

--- a/examples/example-5-shopify/server/package.json
+++ b/examples/example-5-shopify/server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "grist-shopify-connector",
+  "version": "0.0.1",
+  "description": "Grist plugin to Shopify",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "dotenv": "^6.0.0",
+    "shopify-api-node": "^2.15.0"
+  }
+}


### PR DESCRIPTION
The plugin reads Shopify credentials from a local file, then allows users to import Shopify data by talking to Shopify's API.